### PR TITLE
Remove obsolete AZUREJOBS_EXTENSION_VERSION App Setting

### DIFF
--- a/_posts/2016-10-20-deploy-your-azure-fuctions-using-visual-studio-team-services.md
+++ b/_posts/2016-10-20-deploy-your-azure-fuctions-using-visual-studio-team-services.md
@@ -44,7 +44,6 @@ Besides the snippet below, an Azure Function requires an additional storage acco
 		"dependsOn": [ "[concat('Microsoft.Web/Sites/', variables('functionapp_name'))]" ],
 		"properties": {
 			"FUNCTIONS_EXTENSION_VERSION": "~0.6",
-			"AZUREJOBS_EXTENSION_VERSION": "beta",
 
 			"AzureWebJobsDashboard": "[variables('storage_connectionstring')",
 			"AzureWebJobsStorage": "[variables('storage_connectionstring')",


### PR DESCRIPTION
This setting is no longer needed and should be removed. It could cause issues going forward.